### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ os:
 - linux
 - osx
 julia:
-- release
-- nightly
 - 0.4
+- 0.5
+- nightly
 notifications:
   email: false
   slack:


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this package supports julia 0.4 so it should continue to be tested