### PR TITLE
Add ability to retrieve multiple alerts and statisticalmodel objects

### DIFF
--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -106,7 +106,7 @@ function getRepositoryAlert(token::AbstractString; alertID::Int64=0, alertName::
 
     # Always convert to an array for easier processing
     if !isa(alert_list, Array)
-        alert_list = [alert_list]
+        alert_list = Dict{AbstractString, Any}[alert_list]
     end
 
     # Convert alert attribute dates to ZonedDateTime

--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -224,8 +224,8 @@ function postRepositoryAlert(token::AbstractString;
                             alertName::AbstractString="",
                             attributes::Dict=Dict(),
                             objectFields::Dict=Dict(),
+                            alertBody::Union{AbstractString, LightXML.XMLElement}="",
                             errorXML::Union{AbstractString, LightXML.XMLElement}="", # deprecated, remains here for backwards compatibility
-                            alertBody::Union{AbstractString, LightXML.XMLElement}=""
 )
 
     

--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -225,7 +225,7 @@ function postRepositoryAlert(token::AbstractString;
                             attributes::Dict=Dict(),
                             objectFields::Dict=Dict(),
                             alertBody::Union{AbstractString, LightXML.XMLElement}="",
-                            errorXML::Union{AbstractString, LightXML.XMLElement}="", # deprecated, remains here for backwards compatibility
+                            errorXML::Union{AbstractString, LightXML.XMLElement}="" # deprecated, remains here for backwards compatibility
 )
 
     

--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -104,8 +104,22 @@ function getRepositoryAlert(token::AbstractString; alertID::Int64=0, alertName::
                 filterRequired=false
         )
 
-    return alert_list
+    # Always convert to an array for easier processing
+    if !isa(alert_list, Array)
+        alert_list = [alert_list]
+    end
+
+    # Return the first element only if the caller asked for a unique alert, else
+    # return the list even if it only has one element in it
+    if alertID != 0 || alertName != ""
+        return alert_list[1]
+    else
+        return alert_list
+    end
+
 end
+
+
 
 
 

--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -105,7 +105,7 @@ function getRepositoryAlert(token::AbstractString; alertID::Int64=0, alertName::
         )
 
     # Always convert to an array for easier processing
-    if !isa(alert_list, Array)
+    if !isa(alert_list, AbstractArray)
         alert_list = Dict{AbstractString, Any}[alert_list]
     end
 

--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -113,9 +113,9 @@ function getRepositoryAlert(token::AbstractString; alertID::Int64=0, alertName::
     dateFormat = "y-m-dTH:M:S.s+z"
     for alert in alert_list
         alertAttributes = alert["attributes"]
-        alertAttributes["lastUpdated"] = ZonedDateTime(alertAttributes["lastUpdated"], dateFormat)
-        alertAttributes["lastTriggered"] = ZonedDateTime(alertAttributes["lastTriggered"], dateFormat)
-        alertAttributes["lastCleared"] = ZonedDateTime(alertAttributes["lastCleared"], dateFormat)
+        for lastTimestamp in ["lastCleared", "lastTriggered", "lastUpdated"]
+            alertAttributes[lastTimestamp] = isa(alertAttributes[lastTimestamp], AbstractString) ? ZonedDateTime(alertAttributes[lastTimestamp], dateFormat) : alertAttributes[lastTimestamp]
+        end
     end
 
     # Return the first element only if the caller asked for a unique alert, else

--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -121,8 +121,6 @@ end
 
 
 
-
-
 """
 Updates an Alert object from the mPulse repository
 

--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -224,8 +224,15 @@ function postRepositoryAlert(token::AbstractString;
                             alertName::AbstractString="",
                             attributes::Dict=Dict(),
                             objectFields::Dict=Dict(),
+                            errorXML::Union{AbstractString, LightXML.XMLElement}="", # deprecated, remains here for backwards compatibility
                             alertBody::Union{AbstractString, LightXML.XMLElement}=""
 )
+
+    
+    # Renaming errorXML argument to alertBody; safeguard until all code is updated
+    if errorXML != ""
+        alertBody = errorXML
+    end
 
     postRepositoryObject(
         token,

--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -230,7 +230,7 @@ function postRepositoryAlert(token::AbstractString;
 
     
     # Renaming errorXML argument to alertBody; safeguard until all code is updated
-    if errorXML != ""
+    if isempty(alertBody) && errorXML != ""
         alertBody = errorXML
     end
 

--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -109,6 +109,15 @@ function getRepositoryAlert(token::AbstractString; alertID::Int64=0, alertName::
         alert_list = [alert_list]
     end
 
+    # Convert alert attribute dates to ZonedDateTime
+    dateFormat = "y-m-dTH:M:S.s+z"
+    for alert in alert_list
+        alertAttributes = alert["attributes"]
+        alertAttributes["lastUpdated"] = ZonedDateTime(alertAttributes["lastUpdated"], dateFormat)
+        alertAttributes["lastTriggered"] = ZonedDateTime(alertAttributes["lastTriggered"], dateFormat)
+        alertAttributes["lastCleared"] = ZonedDateTime(alertAttributes["lastCleared"], dateFormat)
+    end
+
     # Return the first element only if the caller asked for a unique alert, else
     # return the list even if it only has one element in it
     if alertID != 0 || alertName != ""

--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -224,7 +224,7 @@ function postRepositoryAlert(token::AbstractString;
                             alertName::AbstractString="",
                             attributes::Dict=Dict(),
                             objectFields::Dict=Dict(),
-                            errorXML::Union{AbstractString, LightXML.XMLElement}=""
+                            alertBody::Union{AbstractString, LightXML.XMLElement}=""
 )
 
     postRepositoryObject(
@@ -233,7 +233,7 @@ function postRepositoryAlert(token::AbstractString;
         Dict{Symbol, Any}(:id => alertID, :name => alertName),
         attributes = attributes,
         objectFields = objectFields,
-        body = errorXML
+        body = alertBody
     )
     
     return nothing

--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -97,13 +97,14 @@ You can clear the cache for this tenant using [`mPulseAPI.clearAlertCache`](@ref
 """
 function getRepositoryAlert(token::AbstractString; alertID::Int64=0, alertName::AbstractString="")
 
-    alert = getRepositoryObject(
+    alert_list = getRepositoryObject(
                 token,
                 "alert",
-                Dict{Symbol, Any}(:id => alertID, :name => alertName)
+                Dict{Symbol, Any}(:id => alertID, :name => alertName),
+                filterRequired=false
         )
 
-    return alert
+    return alert_list
 end
 
 

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -111,7 +111,7 @@ function getRepositoryDomain(token::AbstractString; domainID::Int64=0, appKey::A
 
     # Always convert to an array for easier processing
     if !isa(domain_list, Array)
-        domain_list = [domain_list]
+        domain_list = Dict{AbstractString, Any}[domain_list]
     end
 
     for domain in domain_list

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -110,7 +110,7 @@ function getRepositoryDomain(token::AbstractString; domainID::Int64=0, appKey::A
         )
 
     # Always convert to an array for easier processing
-    if !isa(domain_list, Array)
+    if !isa(domain_list, AbstractArray)
         domain_list = Dict{AbstractString, Any}[domain_list]
     end
 

--- a/src/StatisticalModel.jl
+++ b/src/StatisticalModel.jl
@@ -116,8 +116,7 @@ function getRepositoryStatModel(token::AbstractString; statModelID::Int64=0, sta
     else
         return statModel_list
     end
-
-    return statModel_list
+    
 end
 
 

--- a/src/StatisticalModel.jl
+++ b/src/StatisticalModel.jl
@@ -106,7 +106,7 @@ function getRepositoryStatModel(token::AbstractString; statModelID::Int64=0, sta
 
     # Always convert to an array for easier processing
     if !isa(statModel_list, Array)
-        statModel_list = [statModel_list]
+        statModel_list = Dict{AbstractString, Any}[statModel_list]
     end    
 
     # Return the first element only if the caller asked for a unique statisticalmodel, else

--- a/src/StatisticalModel.jl
+++ b/src/StatisticalModel.jl
@@ -97,13 +97,27 @@ You can clear the cache for this tenant using [`mPulseAPI.clearStatModelCache`](
 """
 function getRepositoryStatModel(token::AbstractString; statModelID::Int64=0, statModelName::AbstractString="")
 
-    statModel = getRepositoryObject(
+    statModel_list = getRepositoryObject(
                 token,
                 "statisticalmodel",
-                Dict{Symbol, Any}(:id => statModelID, :name => statModelName)
+                Dict{Symbol, Any}(:id => statModelID, :name => statModelName),
+                filterRequired=false
         )
 
-    return statModel
+    # Always convert to an array for easier processing
+    if !isa(statModel_list, Array)
+        statModel_list = [statModel_list]
+    end    
+
+    # Return the first element only if the caller asked for a unique statisticalmodel, else
+    # return the list even if it only has one element in it
+    if statModelID != 0 || statModelName != ""
+        return statModel_list[1]
+    else
+        return statModel_list
+    end
+
+    return statModel_list
 end
 
 

--- a/src/StatisticalModel.jl
+++ b/src/StatisticalModel.jl
@@ -105,7 +105,7 @@ function getRepositoryStatModel(token::AbstractString; statModelID::Int64=0, sta
         )
 
     # Always convert to an array for easier processing
-    if !isa(statModel_list, Array)
+    if !isa(statModel_list, AbstractArray)
         statModel_list = Dict{AbstractString, Any}[statModel_list]
     end    
 

--- a/src/mPulseAPI.jl
+++ b/src/mPulseAPI.jl
@@ -34,7 +34,7 @@ mPulseAPI
 using Base.Dates
 import Base: @__doc__
 
-using Requests, LightXML, HttpCommon, Formatting
+using Requests, LightXML, HttpCommon, Formatting, TimeZones
 
 # Tells docgen.jl to document internal methods as well
 const __document_internal = true


### PR DESCRIPTION
To aid in analysis of Dynamic Alerting Beta3 efforts, allow the user to retrieve all available alerts or statisticalmodel object types if the associated objectID is not set. 