### PR TITLE
Fix julia 0.4 errors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "mPulseAPI"
 uuid = "314d2b54-f2c3-11ea-15f2-0bcf2fc50b35"
 authors = ["Akamai mPulse DSWB <dswb@akamai.com>"]
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/mPulseAPI.jl
+++ b/src/mPulseAPI.jl
@@ -137,8 +137,8 @@ function readdocs(name::AbstractString, replacers=[]; indent=0)
         try
             data = Formatting.format(data, replacers...)
         catch
-            println(replacers)
-            println(data)
+            @warn replacers
+            @warn data
             rethrow()
         end
     end


### PR DESCRIPTION
This MR converts our exception handling to a more Julia 1.6 method. In some cases we were still referring to Julia 0.4 exceptions that no longer exist in Julia 1.6