### PR TITLE
Handle cases where no objects are found in the repository

### DIFF
--- a/src/Alert.jl
+++ b/src/Alert.jl
@@ -110,7 +110,7 @@ function getRepositoryAlert(token::AbstractString; alertID::Int64=0, alertName::
     end
 
     # Convert alert attribute dates to ZonedDateTime
-    dateFormat = "y-m-dTH:M:S.s+z"
+    dateFormat = DateFormat("y-m-dTH:M:S.s+z")
     for alert in alert_list
         alertAttributes = alert["attributes"]
         for lastTimestamp in ["lastCleared", "lastTriggered", "lastUpdated"]

--- a/src/RepositoryAPI.jl
+++ b/src/RepositoryAPI.jl
@@ -496,9 +496,13 @@ function getHttpRequest(token::AbstractString, objectType::AbstractString, searc
         object_list = [object]
     end
 
-
     if length(object_list) == 0
-        throw(mPulseAPIException("An object matching $debugID was not returned", resp))
+        # Either no objects are defined in the repository, or the specific object was not found
+        if debugID == "(all)"
+            throw(mPulseAPIException("There are no objects defined in the $objectType repository.", resp))
+        else
+            throw(mPulseAPIException("An object matching $debugID was not returned", resp))
+        end
     # If caller has passed in a filter key, then we should only get a single object
     elseif isKeySet && length(object_list) > 1
         throw(mPulseAPIException("Found too many matching objects with IDs=($(map(d->d["id"], object_list)))", resp))

--- a/src/RepositoryAPI.jl
+++ b/src/RepositoryAPI.jl
@@ -496,6 +496,7 @@ function getHttpRequest(token::AbstractString, objectType::AbstractString, searc
         object_list = [object]
     end
 
+
     if length(object_list) == 0
         # Either no objects are defined in the repository, or the specific object was not found
         if debugID == "(all)"


### PR DESCRIPTION
More informative error message when only an authToken is used, and the user wants all objects from the corresponding repository