### PR TITLE
Use Format.jl instead of Formatting.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,12 @@
 name = "mPulseAPI"
 uuid = "314d2b54-f2c3-11ea-15f2-0bcf2fc50b35"
 authors = ["Akamai mPulse DSWB <dswb@akamai.com>"]
-version = "1.2.1"
+version = "1.2.2"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
+Format = "1fa38f19-a742-5d3f-a2b9-30dd87b9d5f8"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
@@ -14,7 +14,7 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
 DataFrames = "1.6.1"
-Formatting = "0.4.2"
+Format = "1.3"
 HTTP = "1.9.15"
 JSON = "0.21.4"
 LightXML = "0.9.1"

--- a/docs/build-docs.jl
+++ b/docs/build-docs.jl
@@ -19,7 +19,7 @@
 ###############################################################################################
 
 using ArgParse
-import Formatting, Pkg, YAML, InteractiveUtils
+import Format, Pkg, YAML, InteractiveUtils
 import InteractiveUtils.subtypes
 
 s = ArgParseSettings()
@@ -114,7 +114,7 @@ function symbol2dict(file_deets::Dict, k, k_doc)
                 text = "",
                 binding = k
             )]
-            local cm = `grep -rEl ^$(Formatting.format(declarator[Base.Docs.Binding], name)) $(dirname(pathof(modl)))`
+            local cm = `grep -rEl ^$(Format.format(declarator[Base.Docs.Binding], name)) $(dirname(pathof(modl)))`
 
             possible_path = filter(x -> !occursin(".swp", x), readlines(cm))
             if !isempty(length(possible_path))
@@ -174,7 +174,7 @@ function symbol2dict(file_deets::Dict, k, k_doc)
 
         if string(fn) != name
             # This is an alias, so we should use its own documentation
-            line = findlast(contains(Regex("^$(Formatting.format(declarator[Base.Docs.Binding], name))")), lines)
+            line = findlast(contains(Regex("^$(Format.format(declarator[Base.Docs.Binding], name))")), lines)
             push!(retvals, Dict(
                     :module   => string(modl),
                     :name     => name,
@@ -298,15 +298,15 @@ function symbol2dict(file_deets::Dict, k, k_doc)
             retvals[1][:name] = retvals[1][:basename]
         end
     else
-        line = findlast(contains(Regex("^\\s*$(Formatting.format(declarator[typ], replace(name, r"([{}])" => s"\\\1")))")), lines)
+        line = findlast(contains(Regex("^\\s*$(Format.format(declarator[typ], replace(name, r"([{}])" => s"\\\1")))")), lines)
 
         # We couldn't find the exact type, but it's possible this was an alias of a type, so is defined as a `const`
         if line == nothing && typeof(k) == Base.Docs.Binding
-            line = findlast(contains(Regex("^$(Formatting.format(declarator[Base.Docs.Binding], replace(name, r"([{}])" => s"\\\1")))")), lines)
+            line = findlast(contains(Regex("^$(Format.format(declarator[Base.Docs.Binding], replace(name, r"([{}])" => s"\\\1")))")), lines)
         end
 
         if line == nothing
-            println(Regex("^\\s*$(Formatting.format(declarator[typ], replace(name, r"([{}])" => s"\\\1")))"))
+            println(Regex("^\\s*$(Format.format(declarator[typ], replace(name, r"([{}])" => s"\\\1")))"))
             printwarn("$typ $name not found in $file")
             return retvals
         end
@@ -527,7 +527,7 @@ function getSymbols(modl::Module; order=[Module, DataType, Macro, Function, Base
     expo_order = Dict(true => "1", false => "2")
     type_order = Dict(zip(order, 1:length(order)))
 
-    sort!(symbols, by = x -> Formatting.format("{3}.{1}.{2}.{4:04d}.{5}", expo_order[x[:exported]], type_order[x[:type]], x[:file], x[:line], x[:name]))
+    sort!(symbols, by = x -> Format.format("{3}.{1}.{2}.{4:04d}.{5}", expo_order[x[:exported]], type_order[x[:type]], x[:file], x[:line], x[:name]))
 
     if Pkg.project().path != proj_path
         Pkg.activate(dirname(proj_path))
@@ -649,7 +649,7 @@ function processModulePage(page::Page, mdfile_path::AbstractString)
             # Use HTML here because markdown doesn't support inserting classes into UL and LI elements
             println(md, """<ul class="symbols">""")
             for s in Base.sort(filter(s -> s[:type] != Module, file_symbs), by = s->(!s[:exported], s[:name]))
-                Formatting.printfmtln(md, """<li class="{3:s}" title="{3:s}"><a href="{2:s}">{1:s}</a></li>""", s[:name], joinpath("..", replace(refids[string(s[:module], ".", s[:name])], r"\.md($|#)" => s".html\1")), s[:exported] ? "exported" : "internal")
+                Format.printfmtln(md, """<li class="{3:s}" title="{3:s}"><a href="{2:s}">{1:s}</a></li>""", s[:name], joinpath("..", replace(refids[string(s[:module], ".", s[:name])], r"\.md($|#)" => s".html\1")), s[:exported] ? "exported" : "internal")
             end
             println(md, """</ul>""")
         end

--- a/src/QueryAPI.jl
+++ b/src/QueryAPI.jl
@@ -10,7 +10,7 @@
 #
 ###################################################
 
-using DataFrames, JSON, Formatting
+using DataFrames, JSON, Format
 
 const nullval = missing
 

--- a/src/mPulseAPI.jl
+++ b/src/mPulseAPI.jl
@@ -15,7 +15,7 @@ module mPulseAPI
 
 using Dates
 
-using LightXML, Formatting, TimeZones, DataFrames
+using LightXML, Format, TimeZones, DataFrames
 import HTTP
 export LightXML
 
@@ -123,7 +123,7 @@ function readdocs(name::AbstractString, replacers=[]; indent=0)
 
         # And run the whole thing through format
         try
-            data = Formatting.format(data, replacers...)
+            data = Format.format(data, replacers...)
         catch
             @warn replacers
             @warn data


### PR DESCRIPTION
This fixes several serious bugs that are present in the Formatting.jl package (which Format.jl was originally based on)